### PR TITLE
Article version support

### DIFF
--- a/feeds.py
+++ b/feeds.py
@@ -87,7 +87,7 @@ def footnote_text(raw_footnote_text):
     return text
 
 
-@fattrs('doc', 'article_version as article_version')
+@fattrs('doc', 'article_version')
 def article_list(doc, article_version):
     if os.path.isfile(doc):
         return [article_wrapper(doc, article_version)]


### PR DESCRIPTION
This retains the ability to extract the article version number from the file name, if present, or to specify the version at the time of scraping. It also makes version a property of an article object.
