### PR TITLE
Consistent output

### DIFF
--- a/feeds.py
+++ b/feeds.py
@@ -570,6 +570,8 @@ def remove_empty_lists(res):
             delete_key_if_empty('fragments', article)
             # Delete empty citations list
             delete_key_if_empty('citations', article)
+            # Delete empty impact-statement list
+            delete_key_if_empty('impact-statement', article)
 
     return res
 
@@ -578,6 +580,7 @@ def scrape(docs_dir, process=None, article_version=None):
         import scraper
         mod = __import__(__name__)
         res = scraper.scrape(mod, doc=docs_dir, article_version=article_version)
+        res = remove_empty_lists(res)
         if process:
             res = process(res)
 
@@ -590,7 +593,7 @@ def main(args):
         print 'Usage: python feeds.py <xml [dir|file]>'
         exit(1)
     docs_dir = args[0]
-    print scrape(docs_dir, process=remove_empty_lists)
+    print scrape(docs_dir)
 
 
 if __name__ == '__main__':

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 source install.sh > /dev/null
-pylint -E elife_ga_metrics/*.py elife_ga_metrics/test/*.py
+pylint -E tests/*.py
 python -m unittest discover --verbose --catch --start-directory tests/ --pattern "*.py"

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -50,7 +50,7 @@ class TestContent(base.BaseCase):
                 LOG.info('skipping %s, path `%s` not found', xml_file, eif_file)
                 continue
             
-            generated_eif = scraper.scrape(feeds, doc=xml_path)[0]['article'][0]
+            generated_eif = json.loads(feeds.scrape(xml_path, lambda x: x[0]['article'][0]))
             expected_eif = json.load(open(eif_file))
 
             LOG.info("testing %s", xml_path)
@@ -83,7 +83,7 @@ class TestContent(base.BaseCase):
                 LOG.info('skipping %s, path `%s` not found', xml_file, eif_path)
                 continue
 
-            generated_eif = scraper.scrape(feeds, doc=xml_path)[0]['article'][0]
+            generated_eif = json.loads(feeds.scrape(xml_path, lambda x: x[0]['article'][0]))
             # a list of maps with keys 'description' and 'data'
             eif_partial_tests = json.load(open(eif_path))
 


### PR DESCRIPTION
We were getting different results when using `feeds.py` on the commandline and using the test suite. This should resolve that issue.

The remove_empty_lists method wasn't being used for the commandline output but not for elife-bit or this test suite.

Now all tests should be passing except for:

elife-01911-v1.json
{'dic_item_added': ["root['contributors'][2]['email']"]}

There is an email address in the contributor element but it is should be there:

expected is:

```
{
  "type": "author",
  "surname": "Mikkelsen",
  "given-names": "Jacob G",
  "id": "author-9053",
  "corresp": "yes",
  "references": {
    "competing-interest": [
      "conf1"
    ]
  },
  "affiliations": [
    {
      "institution": "Aarhus University",
      "city": "Aarhus",
      "country": "Denmark",
      "email": "giehm@hum-gen.au.dk"
    }
  ]
}
```

generated is:

```
{
  "affiliations": [
    {
      "city": "Aarhus",
      "country": "Denmark",
      "email": "giehm@hum-gen.au.dk",
      "institution": "Aarhus University"
    }
  ],
  "corresp": "yes",
  "email": "giehm@hum-gen.au.dk",
  "given-names": "Jacob G",
  "id": "author-9053",
  "references": {
    "competing-interest": [
      "conf1"
    ]
  },
  "surname": "Mikkelsen",
  "type": "author"
}
```
