### PR TITLE
Develop to master, backwards compatible email format

### DIFF
--- a/feeds.py
+++ b/feeds.py
@@ -536,6 +536,11 @@ def contributors(article):
                 if contributor.get(property):
                     del contributor[property]
 
+        if 'email' in contributor:
+            if type(contributor['email']) == list:
+                # Take the first email
+                contributor['email'] = contributor['email'][0]
+
     return contributor_list
 
 @fattrs('this as article')


### PR DESCRIPTION
Due to changes coming soon in the elifetools parser, the next release, and the develop branch, returns email as a list. This will make the jats-scraper compatible with a string or a list, taking only the first email from a list, for EIF schema compatibility.