### PR TITLE
Python 3 support initial changes

### DIFF
--- a/feeds.py
+++ b/feeds.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 __author__ = 'Luke Skibinski <l.skibinski@elifesciences.org>, John Root<john.root@digirati.co.uk>'
 __copyright__ = 'eLife Sciences'
 __licence__ = 'GNU General Public License (GPL)'
@@ -643,10 +645,10 @@ def scrape(docs_dir, process=None, article_version=None):
 
 def main(args):
     if not len(args) == 1:
-        print 'Usage: python feeds.py <xml [dir|file]>'
+        print('Usage: python feeds.py <xml [dir|file]>')
         exit(1)
     docs_dir = args[0]
-    print scrape(docs_dir)
+    print(scrape(docs_dir))
 
 
 if __name__ == '__main__':

--- a/parse_string.py
+++ b/parse_string.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import os
 import scraper
 
@@ -6,4 +7,4 @@ doc_str = open("elife00013.xml", "r").read()
 res = scraper.scrape(mod, doc=doc_str)
 
 import json
-print json.dumps(res, indent=4)
+print(json.dumps(res, indent=4))

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,6 @@ pylint==1.4.4
 pytz==2015.4
 deepdiff==0.5.9
 -e hg+https://bitbucket.org/lskibinski/scraper#egg=scraper
-elifetools==0.1.6
+#elifetools==0.1.6
+git+https://github.com/elifesciences/elife-tools.git@a55a42e01f8d4f68067b61d58894b9d67a45c53a#egg=elifetools
 jmespath==0.9.0

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -1,4 +1,5 @@
-import base
+from __future__ import print_function
+from tests import base
 import json
 import os
 from os.path import join
@@ -61,9 +62,9 @@ class TestContent(base.BaseCase):
 
         if len(ddiffs):
             for attr, value in ddiffs.items():
-                print attr
+                print(attr)
                 pprint(value)
-                print "\n"
+                print("\n")
             self.assertTrue(False)
 
 
@@ -111,12 +112,12 @@ class TestContent(base.BaseCase):
 
         if len(ddiffs):
             for attr, values in ddiffs.items():
-                print attr
+                print(attr)
 
                 for desc, value in values.items():
-                    print desc.encode('utf-8')
+                    print(desc.encode('utf-8'))
                     pprint(value)
-                    print "\n"
+                    print("\n")
             self.assertTrue(False)
 
     def byteify(self, input):

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,6 @@
+[tox]
+skipsdist = True
+envlist = py27,py35
+[testenv]
+deps = -rrequirements.txt
+commands = python -m unittest discover --verbose --catch --start-directory tests/ --pattern "*.py"


### PR DESCRIPTION
As `jats-scraper` is a dependency of `elife-bot` we need to bring in Python 3 support in order to allow full Python 3 support for `elife-bot`.

I have made the initial changes. I have got to the point where it is complaining about the Python 2'ness of [scraper](https://bitbucket.org/lskibinski/scraper). I understand that it has been superseded by [et3](https://bitbucket.org/lskibinski/et3/src/5aabdfce6cd6?at=default) and wondered if `jats-scraper` can now be refactored to use `et3` instead of `scraper`?